### PR TITLE
fix: build errors from 2019 posts

### DIFF
--- a/blog/2019/2019-02-06-january-milestone.md
+++ b/blog/2019/2019-02-06-january-milestone.md
@@ -18,9 +18,9 @@ Last month we implemented the strategy resolver, JWT strategy class and authenti
 * `GET /Users/me` display the logged in user of the application
 
 The following picture describes how the authentication mechanism works:
-<p align="center"> 
-<img src="https://strongloop.com/blog-assets/2019/01/auth_endpoints.png" alt="authentication endpoints in the example" style="width: 800px"/>
-</p>
+
+<img src="https://strongloop.com/blog-assets/2019/01/auth_endpoints.png" alt="authentication endpoints in the example"/>
+
 This month our discussion focused on dividing the responsibilities among controller, repository and services/utilities. 
 
 The login related logic should be extracted into a service which could be shared among different clients, like REST, gRPC and WebSocket. Those logic include taking in credentials, verifying users, generating and decoding access token. The login service receives User's repository via DI. As the first implementation, we simply keep them as utils. They will be refactored into service in story [Refactor authentication util functions into a service](https://github.com/strongloop/loopback4-example-shopping/issues/40)

--- a/blog/2019/2019-05-03-april-milestone.md
+++ b/blog/2019/2019-05-03-april-milestone.md
@@ -2,7 +2,7 @@
 title: LoopBack 4 April 2019 Milestone Update
 date: 2019-05-03
 authors: emonddr
-slug: /strongblog/april-2019-milestone/
+slug: april-2019-milestone
 tags: [Milestone update]
 ---
 

--- a/blog/2019/2019-07-24-building-an-online-game-with-loopback-4-pt5.md
+++ b/blog/2019/2019-07-24-building-an-online-game-with-loopback-4-pt5.md
@@ -2,7 +2,7 @@
 title: Building an Online Game With LoopBack 4 - Deploying our Application to Kubernetes on IBM Cloud (Part 5)
 date: 2019-07-24
 authors: wenbo
-slug: /strongblog/building-an-online-game-with-loopback-4-pt5/
+slug: building-an-online-game-with-loopback-4-pt5
 tags: [how-to]
 ---
 

--- a/blog/2019/2019-12-18-loopback-2019-review.md
+++ b/blog/2019/2019-12-18-loopback-2019-review.md
@@ -2,7 +2,7 @@
 title: LoopBack 2019 Year in Review
 date: 2019-12-18
 authors: dwhiteley
-slug: /strongblog/loopback-2019-review/
+slug: loopback-2019-review
 tags: [community, news]
 ---
 


### PR DESCRIPTION
- Removed leading and trailing forward slash in slugs
- Removed `p` tag encapsulating `img` tag

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>